### PR TITLE
Fixed null reference exception on RouteHandler for attribute routes.

### DIFF
--- a/DeveloperTools/Controllers/RoutesController.cs
+++ b/DeveloperTools/Controllers/RoutesController.cs
@@ -194,7 +194,7 @@ namespace DeveloperTools.Controllers
                 rm.Url = GetUrl(rr);
             }
 
-            rm.RouteHandler = rr.RouteHandler.GetType().ToString();
+            rm.RouteHandler = rr.RouteHandler?.GetType().ToString();
             rm.Defaults = GetRouteValueDictionary(rr.Defaults);
             rm.Constraints = GetRouteValueDictionary(rr.Constraints);
             rm.DataTokens = GetRouteValueDictionary(rr.DataTokens);


### PR DESCRIPTION
RoutesController crashes with a null reference exception when attempting to get type of route handler on attribute routes.